### PR TITLE
Fix identifier comparison in service

### DIFF
--- a/custom_components/ori/services.py
+++ b/custom_components/ori/services.py
@@ -63,7 +63,7 @@ def get_device(device_entry: dr.DeviceEntry, config: ConfigEntry[AquatlantisOriC
     """Get the device data for a config entry."""
     device_data: Device | None = None
     for device in config.runtime_data.get_devices():
-        if device_entry.identifiers == {(DOMAIN, device.id)}:
+        if device_entry.identifiers == {(DOMAIN, str(device.id))}:
             device_data = device
 
     if device_data is None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->
This fixes the following errors:
```
2025-10-07 16:45:04.763 ERROR (MainThread) [homeassistant.helpers.script.websocket_api_script] websocket_api script: Error executing script. Error for call_service at pos 1: Device not found
2025-10-07 16:45:04.763 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] [137887995850048] Device not found
```

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
