### PR TITLE
Support upstream device availability state

### DIFF
--- a/custom_components/ori/binary_sensor.py
+++ b/custom_components/ori/binary_sensor.py
@@ -87,18 +87,16 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class OriBinarySensor(OriEntity, BinarySensorEntity):
+class OriBinarySensor(OriEntity[OriBinarySensorEntityDescription], BinarySensorEntity):
     """Representation of a Aquatlantis Ori binary sensor."""
-
-    entity_description: OriBinarySensorEntityDescription
 
     @property
     def is_on(self) -> bool:
         """Return true if the binary sensor is on."""
-        return self.entity_description.value_fn(self._device)
+        return self.description.value_fn(self._device)
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
         # Handle the case locally so the connectivity sensor is always available.
-        return self.entity_description.available_fn(self._device)
+        return self.description.available_fn(self._device)

--- a/custom_components/ori/binary_sensor.py
+++ b/custom_components/ori/binary_sensor.py
@@ -12,9 +12,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from aquatlantis_ori import AquatlantisOriClient, Device, SensorType, SensorValidType, StatusType
+from aquatlantis_ori import AquatlantisOriClient, Device, SensorType, SensorValidType
 
-from .entity import OriEntity, OriEntityDescription
+from .entity import OriEntity, OriEntityDescription, is_device_available
 
 PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=10)
@@ -33,14 +33,16 @@ DESCRIPTIONS: list[OriBinarySensorEntityDescription] = [
         translation_key="status",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        value_fn=lambda device: device.status == StatusType.ONLINE,
+        value_fn=is_device_available,
     ),
     OriBinarySensorEntityDescription(
         key="water_temperature_problem",
         translation_key="water_temperature_problem",
         device_class=BinarySensorDeviceClass.PROBLEM,
         available_fn=lambda device: (
-            device.status == StatusType.ONLINE and device.sensor_valid == SensorValidType.VALID and device.water_temperature_thresholds is not None
+            is_device_available(device)
+            and device.sensor_valid == SensorValidType.VALID
+            and device.water_temperature_thresholds is not None
         ),
         value_fn=lambda device: (
             True

--- a/custom_components/ori/binary_sensor.py
+++ b/custom_components/ori/binary_sensor.py
@@ -12,9 +12,9 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from aquatlantis_ori import AquatlantisOriClient, Device, SensorType, SensorValidType
+from aquatlantis_ori import AquatlantisOriClient, AvailabilityType, Device, SensorType, SensorValidType
 
-from .entity import OriEntity, OriEntityDescription, is_device_available
+from .entity import OriEntity, OriEntityDescription
 
 PARALLEL_UPDATES = 0
 SCAN_INTERVAL = timedelta(seconds=10)
@@ -33,14 +33,14 @@ DESCRIPTIONS: list[OriBinarySensorEntityDescription] = [
         translation_key="status",
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
-        value_fn=is_device_available,
+        value_fn=lambda device: device.availability_state == AvailabilityType.AVAILABLE,
     ),
     OriBinarySensorEntityDescription(
         key="water_temperature_problem",
         translation_key="water_temperature_problem",
         device_class=BinarySensorDeviceClass.PROBLEM,
         available_fn=lambda device: (
-            is_device_available(device)
+            device.availability_state == AvailabilityType.AVAILABLE
             and device.sensor_valid == SensorValidType.VALID
             and device.water_temperature_thresholds is not None
         ),

--- a/custom_components/ori/button.py
+++ b/custom_components/ori/button.py
@@ -104,12 +104,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class OriButton(OriEntity, ButtonEntity):
+class OriButton(OriEntity[OriButtonEntityDescription], ButtonEntity):
     """Representation of a Aquatlantis Ori button."""
-
-    entity_description: OriButtonEntityDescription
 
     def press(self) -> None:
         """Handle the button press."""
-        _LOGGER.info("Pressing button %s on device %s", self.entity_description.key, self._device.devid)
-        self.entity_description.press_fn(self._device)
+        _LOGGER.info("Pressing button %s on device %s", self.description.key, self._device.devid)
+        self.description.press_fn(self._device)

--- a/custom_components/ori/entity.py
+++ b/custom_components/ori/entity.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from functools import cached_property
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -28,17 +29,15 @@ class OriEntityDescription(EntityDescription):
     state_attributes_fn: Callable[[Device], dict[str, Any]] = lambda _: {}
 
 
-class OriEntity(Entity):
+class OriEntity[DescriptionT: OriEntityDescription](Entity):
     """Representation of a Aquatlantis Ori entity."""
-
-    entity_description: OriEntityDescription
 
     _attr_has_entity_name = True
 
     def __init__(
         self,
         config_entry: ConfigEntry[AquatlantisOriClient],
-        description: OriEntityDescription,
+        description: DescriptionT,
         device: Device,
     ) -> None:
         """Initialize the Aquatlantis Ori entity."""
@@ -60,11 +59,16 @@ class OriEntity(Entity):
         )
 
     @property
+    def description(self) -> DescriptionT:
+        """Return the typed entity description."""
+        return cast(DescriptionT, self.entity_description)
+
+    @cached_property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._device.availability_state == AvailabilityType.AVAILABLE and self.entity_description.available_fn(self._device)
+        return self._device.availability_state == AvailabilityType.AVAILABLE and self.description.available_fn(self._device)
 
-    @property
+    @cached_property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
-        return self.entity_description.state_attributes_fn(self._device)
+        return self.description.state_attributes_fn(self._device)

--- a/custom_components/ori/entity.py
+++ b/custom_components/ori/entity.py
@@ -18,6 +18,7 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 AVAILABLE_STATE_NAME = "AVAILABLE"
+AVAILABLE_STATE_VALUE = 2
 
 
 def is_device_available(device: Device) -> bool:
@@ -29,7 +30,10 @@ def is_device_available(device: Device) -> bool:
     """
     availability_state = getattr(device, "availability_state", None)
     if availability_state is not None:
-        return getattr(availability_state, "name", None) == AVAILABLE_STATE_NAME
+        if getattr(availability_state, "name", None) == AVAILABLE_STATE_NAME:
+            return True
+
+        return getattr(availability_state, "value", availability_state) == AVAILABLE_STATE_VALUE
 
     return device.status == StatusType.ONLINE
 

--- a/custom_components/ori/entity.py
+++ b/custom_components/ori/entity.py
@@ -11,31 +11,11 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 
-from aquatlantis_ori import AquatlantisOriClient, Device, StatusType
+from aquatlantis_ori import AquatlantisOriClient, AvailabilityType, Device
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-AVAILABLE_STATE_NAME = "AVAILABLE"
-AVAILABLE_STATE_VALUE = 2
-
-
-def is_device_available(device: Device) -> bool:
-    """Return the effective device availability.
-
-    Prefer the derived availability exposed by newer python-aquatlantis-ori
-    versions, but keep compatibility with older releases that only expose the
-    raw status field.
-    """
-    availability_state = getattr(device, "availability_state", None)
-    if availability_state is not None:
-        if getattr(availability_state, "name", None) == AVAILABLE_STATE_NAME:
-            return True
-
-        return getattr(availability_state, "value", availability_state) == AVAILABLE_STATE_VALUE
-
-    return device.status == StatusType.ONLINE
 
 
 @dataclass(kw_only=True, frozen=True)
@@ -82,7 +62,7 @@ class OriEntity(Entity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return is_device_available(self._device) and self.entity_description.available_fn(self._device)
+        return self._device.availability_state == AvailabilityType.AVAILABLE and self.entity_description.available_fn(self._device)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/ori/entity.py
+++ b/custom_components/ori/entity.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from functools import cached_property
 from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
@@ -63,12 +62,12 @@ class OriEntity[DescriptionT: OriEntityDescription](Entity):
         """Return the typed entity description."""
         return cast(DescriptionT, self.entity_description)
 
-    @cached_property
+    @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._device.availability_state == AvailabilityType.AVAILABLE and self.description.available_fn(self._device)
 
-    @cached_property
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return entity specific state attributes."""
         return self.description.state_attributes_fn(self._device)

--- a/custom_components/ori/entity.py
+++ b/custom_components/ori/entity.py
@@ -17,6 +17,22 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
+AVAILABLE_STATE_NAME = "AVAILABLE"
+
+
+def is_device_available(device: Device) -> bool:
+    """Return the effective device availability.
+
+    Prefer the derived availability exposed by newer python-aquatlantis-ori
+    versions, but keep compatibility with older releases that only expose the
+    raw status field.
+    """
+    availability_state = getattr(device, "availability_state", None)
+    if availability_state is not None:
+        return getattr(availability_state, "name", None) == AVAILABLE_STATE_NAME
+
+    return device.status == StatusType.ONLINE
+
 
 @dataclass(kw_only=True, frozen=True)
 class OriEntityDescription(EntityDescription):
@@ -62,7 +78,7 @@ class OriEntity(Entity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-        return self._device.status == StatusType.ONLINE and self.entity_description.available_fn(self._device)
+        return is_device_available(self._device) and self.entity_description.available_fn(self._device)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/ori/light.py
+++ b/custom_components/ori/light.py
@@ -115,15 +115,13 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class OriLightEntity(OriEntity, LightEntity):
+class OriLightEntity(OriEntity[OriLightEntityDescription], LightEntity):
     """Representation of a Aquatlantis Ori light."""
-
-    entity_description: OriLightEntityDescription
 
     def __init__(
         self,
         config_entry: ConfigEntry[AquatlantisOriClient],
-        description: OriEntityDescription,
+        description: OriLightEntityDescription,
         device: Device,
     ) -> None:
         """Initialize light."""
@@ -133,7 +131,7 @@ class OriLightEntity(OriEntity, LightEntity):
 
     def turn_on(self, **kwargs: Any) -> None:  # noqa: ANN401
         """Turn the entity on."""
-        _LOGGER.info("Turning on, or changing light %s on device %s", self.entity_description.key, self._device.devid)
+        _LOGGER.info("Turning on, or changing light %s on device %s", self.description.key, self._device.devid)
         options = LightOptions()
 
         if ATTR_EFFECT in kwargs:
@@ -163,7 +161,7 @@ class OriLightEntity(OriEntity, LightEntity):
 
     def turn_off(self, **_kwargs: Any) -> None:  # noqa: ANN401
         """Turn the entity off."""
-        _LOGGER.info("Turning off light %s on device %s", self.entity_description.key, self._device.devid)
+        _LOGGER.info("Turning off light %s on device %s", self.description.key, self._device.devid)
         self._device.set_mode(ModeType.MANUAL)
         self._device.set_power(PowerType.OFF)
 
@@ -173,7 +171,7 @@ class OriLightEntity(OriEntity, LightEntity):
         return _effect_name(self._device)
 
     @property
-    def color_mode(self) -> ColorMode | str | None:
+    def color_mode(self) -> ColorMode | None:
         """Return the color mode of the light."""
         if self._device.mode == ModeType.AUTOMATIC or self._device.dynamic_mode == DynamicModeType.ON:
             # If the device is in automatic mode or dynamic mode is on, it only supports ON/OFF
@@ -181,7 +179,7 @@ class OriLightEntity(OriEntity, LightEntity):
         return ColorMode.RGBW
 
     @property
-    def supported_color_modes(self) -> set[ColorMode] | set[str] | None:
+    def supported_color_modes(self) -> set[ColorMode] | None:
         """Flag supported color modes."""
         if self._device.mode == ModeType.AUTOMATIC or self._device.dynamic_mode == DynamicModeType.ON:
             # If the device is in automatic mode or dynamic mode is on, it only supports ON/OFF

--- a/custom_components/ori/manifest.json
+++ b/custom_components/ori/manifest.json
@@ -7,6 +7,8 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/golles/ha-aquatlantis-ori/issues",
   "loggers": ["aquatlantis_ori", "custom_components.ori"],
-  "requirements": ["aquatlantis_ori==0.0.13"],
+  "requirements": [
+    "aquatlantis_ori @ https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip"
+  ],
   "version": "0.0.1"
 }

--- a/custom_components/ori/manifest.json
+++ b/custom_components/ori/manifest.json
@@ -7,8 +7,6 @@
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/golles/ha-aquatlantis-ori/issues",
   "loggers": ["aquatlantis_ori", "custom_components.ori"],
-  "requirements": [
-    "aquatlantis_ori @ https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip"
-  ],
+  "requirements": ["aquatlantis_ori==0.0.14"],
   "version": "0.0.1"
 }

--- a/custom_components/ori/number.py
+++ b/custom_components/ori/number.py
@@ -114,16 +114,14 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class OriNumber(OriEntity, NumberEntity):
+class OriNumber(OriEntity[OriNumberDescription], NumberEntity):
     """Representation of a Aquatlantis Ori number entity."""
-
-    entity_description: OriNumberDescription
 
     @property
     def native_value(self) -> float | None:
         """Return the value reported by the number."""
-        return self.entity_description.value_fn(self._device)
+        return self.description.value_fn(self._device)
 
     def set_native_value(self, value: float) -> None:
         """Set new value."""
-        self.entity_description.set_fn(self._device, int(value))
+        self.description.set_fn(self._device, int(value))

--- a/custom_components/ori/sensor.py
+++ b/custom_components/ori/sensor.py
@@ -120,12 +120,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class OriSensor(OriEntity, SensorEntity):
+class OriSensor(OriEntity[OriSensorEntityDescription], SensorEntity):
     """Representation of a Aquatlantis Ori sensor."""
-
-    entity_description: OriSensorEntityDescription
 
     @property
     def native_value(self) -> StateType | datetime:
         """Return the value reported by the sensor."""
-        return self.entity_description.value_fn(self._device)
+        return self.description.value_fn(self._device)

--- a/custom_components/ori/update.py
+++ b/custom_components/ori/update.py
@@ -62,10 +62,8 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class OriUpdate(OriEntity, UpdateEntity):
+class OriUpdate(OriEntity[OriUpdateEntityDescription], UpdateEntity):
     """Representation of a Aquatlantis Ori update entity."""
-
-    entity_description: OriUpdateEntityDescription
 
     @property
     def installed_version(self) -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "aquatlantis_ori @ https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip",
+    "aquatlantis_ori==0.0.14",
     "homeassistant>=2025.7.0",
 ]
 
@@ -57,9 +57,6 @@ source = ["custom_components/ori"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["custom_components/ori"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.mypy]
 python_version = "3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "aquatlantis_ori==0.0.13",
+    "aquatlantis_ori @ https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip",
     "homeassistant>=2025.7.0",
 ]
 
@@ -57,6 +57,9 @@ source = ["custom_components/ori"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["custom_components/ori"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.mypy]
 python_version = "3.14"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -45,12 +45,9 @@ async def test_binary_sensors_no_device(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("enable_all_entities")
-async def test_binary_sensors_available_with_live_mqtt_and_stale_http_offline(
-    hass: HomeAssistant, mock_aquatlantis_client: AsyncMock
-) -> None:
+async def test_binary_sensors_available_with_live_mqtt_and_stale_http_offline(hass: HomeAssistant, mock_aquatlantis_client: AsyncMock) -> None:
     """Test connectivity uses derived availability when HTTP status is stale offline."""
     device = create_test_device({"status": 0})
-    device.availability_state = 2
     mock_aquatlantis_client.get_devices.return_value = [device]
 
     config_entry = await setup_integration(hass)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -42,3 +42,20 @@ async def test_binary_sensors_no_device(hass: HomeAssistant) -> None:
     assert hass.states.get("binary_sensor.test_device_water_temperature") is None
 
     await unload_integration(hass, config_entry)
+
+
+@pytest.mark.usefixtures("enable_all_entities")
+async def test_binary_sensors_available_with_live_mqtt_and_stale_http_offline(
+    hass: HomeAssistant, mock_aquatlantis_client: AsyncMock
+) -> None:
+    """Test connectivity uses derived availability when HTTP status is stale offline."""
+    device = create_test_device({"status": 0})
+    device.availability_state = 2
+    mock_aquatlantis_client.get_devices.return_value = [device]
+
+    config_entry = await setup_integration(hass)
+
+    check_state_value(hass, "binary_sensor.test_device_connectivity", "on")
+    check_state_value(hass, "binary_sensor.test_device_water_temperature", "off")
+
+    await unload_integration(hass, config_entry)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -62,12 +62,9 @@ async def test_sensor_no_temperature(hass: HomeAssistant, mock_aquatlantis_clien
 
 
 @pytest.mark.usefixtures("enable_all_entities")
-async def test_sensors_available_with_live_mqtt_and_stale_http_offline(
-    hass: HomeAssistant, mock_aquatlantis_client: AsyncMock
-) -> None:
+async def test_sensors_available_with_live_mqtt_and_stale_http_offline(hass: HomeAssistant, mock_aquatlantis_client: AsyncMock) -> None:
     """Test sensors stay available when MQTT telemetry is live but HTTP status is stale offline."""
     device = create_test_device({"status": 0})
-    device.availability_state = 2
     mock_aquatlantis_client.get_devices.return_value = [device]
 
     config_entry = await setup_integration(hass)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -59,3 +59,20 @@ async def test_sensor_no_temperature(hass: HomeAssistant, mock_aquatlantis_clien
     assert hass.states.get("sensor.offline_device_water_temperature") is None
 
     await unload_integration(hass, config_entry)
+
+
+@pytest.mark.usefixtures("enable_all_entities")
+async def test_sensors_available_with_live_mqtt_and_stale_http_offline(
+    hass: HomeAssistant, mock_aquatlantis_client: AsyncMock
+) -> None:
+    """Test sensors stay available when MQTT telemetry is live but HTTP status is stale offline."""
+    device = create_test_device({"status": 0})
+    device.availability_state = 2
+    mock_aquatlantis_client.get_devices.return_value = [device]
+
+    config_entry = await setup_integration(hass)
+
+    check_state_value(hass, "sensor.test_device_water_temperature", "25.0")
+    check_state_value(hass, "sensor.test_device_wifi_signal", "-70")
+
+    await unload_integration(hass, config_entry)

--- a/uv.lock
+++ b/uv.lock
@@ -343,8 +343,8 @@ wheels = [
 
 [[package]]
 name = "aquatlantis-ori"
-version = "0.0.1"
-source = { url = "https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip" }
+version = "0.0.14"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", version = "3.13.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14.2'" },
     { name = "aiohttp", version = "3.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
@@ -353,14 +353,9 @@ dependencies = [
     { name = "orjson", version = "3.11.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
     { name = "paho-mqtt" },
 ]
-sdist = { hash = "sha256:9236a4a8e2371cde5f57f0dd7ffde37d32a2d7cf3d3916a9d5c1ea9f8c885aba" }
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = ">=3.12.0" },
-    { name = "mashumaro", specifier = ">=3.16" },
-    { name = "orjson", specifier = ">=3.10.0" },
-    { name = "paho-mqtt", specifier = ">=2.1.0" },
+sdist = { url = "https://files.pythonhosted.org/packages/1a/f1/a912400e3265a7205b99b2d8c77f1bde63bd4cd14a67557cb21f5df978d8/aquatlantis_ori-0.0.14.tar.gz", hash = "sha256:12621d5cfa518b6b10c5086e46d689b6c7c6e7d0cd50d29c050efef0050ed2f0", size = 92292, upload-time = "2026-06-06T11:00:55.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/0c/b7b97b415084eb294c6435713298c0fd7bdbafce69023ff9452f96ba7ce6/aquatlantis_ori-0.0.14-py3-none-any.whl", hash = "sha256:180c068973391594555e7b6cf78b0c5b684ca9da53b76fcd1c7eef80ff399410", size = 20387, upload-time = "2026-06-06T11:00:54.015Z" },
 ]
 
 [[package]]
@@ -1200,7 +1195,7 @@ runhass = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aquatlantis-ori", url = "https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip" },
+    { name = "aquatlantis-ori", specifier = "==0.0.14" },
     { name = "homeassistant", specifier = ">=2025.7.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -343,8 +343,8 @@ wheels = [
 
 [[package]]
 name = "aquatlantis-ori"
-version = "0.0.13"
-source = { registry = "https://pypi.org/simple" }
+version = "0.0.1"
+source = { url = "https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip" }
 dependencies = [
     { name = "aiohttp", version = "3.13.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14.2'" },
     { name = "aiohttp", version = "3.13.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
@@ -353,9 +353,14 @@ dependencies = [
     { name = "orjson", version = "3.11.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
     { name = "paho-mqtt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/7c/eda4068c0370fb4efdfb3cce1876e6f0c89b79559341925191e8132fb4d6/aquatlantis_ori-0.0.13.tar.gz", hash = "sha256:6f493e63eab8b13e6d8a6f60a4463376702df9473a026d7f1fa83a77d97b35d3", size = 77508, upload-time = "2025-10-05T13:06:34.987Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/51/00d65ab18c6f3b10560dccff5c813c58619759169e3416e6bf1065ed60b9/aquatlantis_ori-0.0.13-py3-none-any.whl", hash = "sha256:8a0adf4c403a59fee2712ae143c5930adc0ba42e9e41ab13cbc4c59df9bb4270", size = 19340, upload-time = "2025-10-05T13:06:33.814Z" },
+sdist = { hash = "sha256:9236a4a8e2371cde5f57f0dd7ffde37d32a2d7cf3d3916a9d5c1ea9f8c885aba" }
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = ">=3.12.0" },
+    { name = "mashumaro", specifier = ">=3.16" },
+    { name = "orjson", specifier = ">=3.10.0" },
+    { name = "paho-mqtt", specifier = ">=2.1.0" },
 ]
 
 [[package]]
@@ -1195,7 +1200,7 @@ runhass = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aquatlantis-ori", specifier = "==0.0.13" },
+    { name = "aquatlantis-ori", url = "https://github.com/golles/python-aquatlantis-ori/archive/refs/pull/232/head.zip" },
     { name = "homeassistant", specifier = ">=2025.7.0" },
 ]
 


### PR DESCRIPTION
## Proposed change

This PR switches the integration to the new `device.availability_state` API introduced in golles/python-aquatlantis-ori#232 and updates the dependency to that PR head for now.

That keeps the Home Assistant side small and direct:
- entity availability now checks `AvailabilityType.AVAILABLE`
- the connectivity binary sensor and water temperature problem sensor use the same upstream availability model
- focused regression tests cover the stale HTTP offline plus live MQTT scenario
- Ori entity typing was cleaned up so the branch passes the full validation suite

Validation run on this branch:
- `uv run pytest tests/test_sensor.py tests/test_binary_sensor.py -q`
- `uv run pre-commit run --all-files`

## Breaking change

No user-facing breaking change is intended.

This branch temporarily depends on the upstream library PR head because the integration now uses the new `availability_state` API directly. Once golles/python-aquatlantis-ori#232 is merged and released, this dependency can be switched back to the published package version that contains that API.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works
